### PR TITLE
Update README.md. Only low 2GB is usable for LuaJIT x64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About
 
 This is a wrapper for mmap() to expand the address range of the `MAP_32BIT` flag from 31bits to a full 32bits (i.e. the low 4Gbytes).  This allows access the almost a full 4Gbytes of 32bit addresses.
 
-The main use of this wrapper is to allow LuaJIT to use more then 1Gbyte of ram on Linux.  With this wrapper LuaJIT can use amost a full 4Gbytes of ram.
+The main use of this wrapper is to allow LuaJIT to use more then 1Gbyte of ram on Linux.  With this wrapper LuaJIT can use amost a full 2Gbytes of ram.
 
 Compile
 =======


### PR DESCRIPTION
Quoting Mike Pall:

> However, if I utilize any address over 2 GB (any address with the 31st bit
> set) then I get a segfault in 2.1 git head in what appears to be jitted
> code.

No suprise there. I always said the GC-managed memory must be in
the lowest 2 GB of the address space for x64.

[Yes, you can use the full 4 GB in 32 bit mode on x86.]
